### PR TITLE
センサモジュール ノイズ対策パッチ

### DIFF
--- a/driver_src/hcsr04drv.cpp
+++ b/driver_src/hcsr04drv.cpp
@@ -161,10 +161,13 @@ double HCSR04::sonar(bool oneShotMode)
 		}
 	}
 
-	// 時間の算出
+	double d = DBL_MAX;
+	// 距離の算出
 	if(t != DBL_MAX) {
-		return t * 340 / 2; // 音速=340[m/sec]と仮定, t = 往復に要する時間[sec], 単位 : [m]
-	} else {
-		return DBL_MAX;
+		// 音速=340[m/sec]と仮定, t = 往復に要する時間[sec], 単位 : [m]
+		d = t * 340 / 2;
+		// 距離が1cmいないの場合、正常に取得できない扱いとする。
+		if(d < 0.01) d = DBL_MAX;
 	}
+	return d;
 }

--- a/driver_src/main.cpp
+++ b/driver_src/main.cpp
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <cfloat>
 #include <csignal>
 #include <unistd.h>
 #include <memory>
@@ -74,7 +75,7 @@ int main(int argc, char *argv[])
 			case EdgeDetector::Status::Low	 	: status="L"; p=true; break;
 			case EdgeDetector::Status::High	 	: status="H"; p=true; break;
 			} 
-			if(p) {
+			if(p && dist_filtered != DBL_MAX) {
 				printf("%s", status);
 				printf(" fil : %5.3lf [cm]", dist_filtered*100);
 				printf(" raw : %5.3lf [cm]", dist_raw*100);

--- a/driver_src/util.cpp
+++ b/driver_src/util.cpp
@@ -1,6 +1,6 @@
 #include "util.h"
 #include <cassert>
-
+#include <cfloat>
 
 EdgeDetector::EdgeDetector(double lowThreshold, double highThreshold)
 	: mStatus(Status::Unknown)
@@ -12,7 +12,9 @@ EdgeDetector::EdgeDetector(double lowThreshold, double highThreshold)
 
 EdgeDetector::Level EdgeDetector::level(double value)const
 {
-	if(value <= mLowThreshold) {
+	if(value == DBL_MAX) {
+		return Level::Undefined;
+	} else if(value <= mLowThreshold) {
 		return Level::Low;
 	} else if(value >= mHighThreshold) {
 		return Level::High;

--- a/driver_src/util.h
+++ b/driver_src/util.h
@@ -55,7 +55,7 @@ public:
 	};
 	enum class Level {
 		Low,		// v <= L
-		Undefined, 	// L < v < H
+		Undefined, 	// L < v < H or INF
 		High,		// H <= v
 	};
 


### PR DESCRIPTION
センサ-制御基板間のノイズ対策を強化しました。
変更点：
・エッジ検出器：測定不可時のエッジ状態変更抑止
・HC-SR04ドライバ : 測定値1cm未満(ほぼノイズ)は測定負荷扱とする
・画面表示 : 測定不可時の表示抑止

※下記Backlogチケットと連動
 LEADERS2015_TEAM7-123 センサモジュール ノイズ対策
